### PR TITLE
fix: update ape syntax and usage

### DIFF
--- a/ape_ledger/_cli.py
+++ b/ape_ledger/_cli.py
@@ -53,7 +53,7 @@ def _get_ledger_accounts() -> List[LedgerAccount]:
 
 @cli.command()
 @ape_cli_context()
-@non_existing_alias_argument
+@non_existing_alias_argument()
 @click.option(
     "--hd-path",
     help=(

--- a/ape_ledger/choices.py
+++ b/ape_ledger/choices.py
@@ -24,6 +24,7 @@ class AddressPromptChoice(PromptChoice):
         self._app = app
         self._index_offset = index_offset
         self._page_size = page_size
+        self._choice_index = None
 
         # Must call ``_load_choices()`` to set address choices
         super().__init__([])
@@ -54,7 +55,9 @@ class AddressPromptChoice(PromptChoice):
             # Don't select an address yet if user paged.
             return None
 
-        return super().convert(value, param, ctx)
+        address = super().convert(value, param, ctx)
+        self._choice_index = self.choices.index(address)
+        return address
 
     def get_user_selected_account(self) -> Tuple[str, HDAccountPath]:
         """Returns the selected address from the user along with the HD path.
@@ -67,7 +70,7 @@ class AddressPromptChoice(PromptChoice):
 
             address = self._get_user_selection()
 
-        account_id = self.choice_index
+        account_id = self._choice_index
         return address, self._hd_root_path.get_account_path(account_id)
 
     def _get_user_selection(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
+[tool.mypy]
+exclude = "build/"
+
 [tool.setuptools_scm]
 write_to = "ape_ledger/version.py"
 
@@ -31,6 +34,7 @@ exclude = '''
 
 [tool.pytest.ini_options]
 addopts = """
+	-p no:ape_test
 	--cov-branch
 	--cov-report term
 	--cov-report html

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -46,11 +46,16 @@ def account_connection(mocker, ledger_account):
     return patch
 
 
+@pytest.fixture
+def mock_config_manager(mocker):
+    return mocker.MagicMock()
+
+
 class TestAccountContainer:
-    def test_save_account(self, runner, mock_container):
+    def test_save_account(self, runner, mock_container, mock_config_manager):
         with runner.isolated_filesystem():
             # noinspection PyArgumentList
-            container = AccountContainer(Path("."), LedgerAccount)
+            container = AccountContainer(Path("."), LedgerAccount, mock_config_manager)
             container.save_account(TEST_ALIAS, TEST_ADDRESS, TEST_HD_PATH)
 
             assert_account(f"{TEST_ALIAS}.json", expected_hdpath=TEST_HD_PATH)
@@ -121,5 +126,7 @@ class TestLedgerAccount:
                 account.sign_message(message)
 
             actual = str(err.value)
-            expected = f"Unsupported message-signing specification, (version={unsupported_version})"
+            expected = (
+                f"Unsupported message-signing specification, (version={unsupported_version})."
+            )
             assert actual == expected

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -7,7 +7,7 @@ class TestAddressPromptChoice:
     def test_get_user_selected_account(self, mocker, mock_ethereum_app):
         mock_prompt = mocker.patch("ape_ledger.choices.click.prompt")
         choices = AddressPromptChoice(mock_ethereum_app)
-        choices.choice_index = 1
+        choices._choice_index = 1
 
         # `None` means the user hasn't selected yeet
         # And is entering other keys, possible the paging keys.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,17 +68,17 @@ def test_list(runner, existing_account):
 
 
 def test_add(runner, mock_device_connection):
-    selected_account_id = 1
+    selected_account_id = 0
     result = runner.invoke(cli, ["ledger", "add", TEST_ALIAS], input=str(selected_account_id))
     assert result.exit_code == 0, result.output
     assert (
-        f"SUCCESS: Account '{TEST_ADDRESS}' successfully added with alias '{TEST_ALIAS}'"
+        f"SUCCESS: Account '{TEST_ADDRESS}' successfully added with alias '{TEST_ALIAS}'."
         in result.output
     )
 
     container = _get_container()
     expected_path = container.data_folder.joinpath(f"{TEST_ALIAS}.json")
-    expected_hd_path = f"m/44'/60'/{selected_account_id - 1}'/0/0"
+    expected_hd_path = f"m/44'/60'/{selected_account_id}'/0/0"
     assert_account(expected_path, expected_hdpath=expected_hd_path)
 
 
@@ -88,7 +88,7 @@ def test_add_when_hd_path_specified(
     test_hd_path = "m/44'/60'/0'"
     mock_ethereum_app.hd_root_path = HDBasePath(test_hd_path)
 
-    selected_account_id = 1
+    selected_account_id = 0
     result = runner.invoke(
         cli,
         ["ledger", "add", TEST_ALIAS, "--hd-path", test_hd_path],
@@ -96,21 +96,24 @@ def test_add_when_hd_path_specified(
     )
     assert result.exit_code == 0, result.output
     assert (
-        f"SUCCESS: Account '{TEST_ADDRESS}' successfully added with alias '{TEST_ALIAS}'"
+        f"SUCCESS: Account '{TEST_ADDRESS}' successfully added with alias '{TEST_ALIAS}'."
         in result.output
     )
 
     expected_path = TEST_ACCOUNT_PATH
-    expected_hd_path = f"m/44'/60'/0'/{selected_account_id - 1}"
+    expected_hd_path = f"m/44'/60'/0'/{selected_account_id}"
     assert_account(expected_path, expected_hdpath=expected_hd_path)
 
 
 def test_add_alias_already_exists(
     runner, mock_ethereum_app, mock_device_connection, existing_account
 ):
-    result = runner.invoke(cli, ["ledger", "add", TEST_ALIAS], input="1")
-    assert result.exit_code == 1
-    assert f"ERROR: Account with alias '{TEST_ALIAS}' already in use" in result.output
+    result = runner.invoke(cli, ["ledger", "add", TEST_ALIAS], input="0")
+    assert result.exit_code == 1, result.output
+    assert (
+        f"ERROR: (AliasAlreadyInUseError) Account with alias '{TEST_ALIAS}' already in use."
+        in result.output
+    )
 
 
 def test_delete(runner, existing_account):


### PR DESCRIPTION
### What I did

Handled changes from ape regarding making args and options always callable

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
