### PR TITLE
fix: relax and upgrade eth-account version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "click>=8.0.0",
         "hidapi==0.10.1",
         "eth-ape>=0.1.0a24",
-        "eth-account==0.5.5",
+        "eth-account>=0.5.6,<0.6.0",
         "eth-typing>=2.2.2",
         "eth-utils>=1.10.0",
         "hexbytes==0.2.2",


### PR DESCRIPTION
### What I did

Relax eth account so it can work with 0.5.6

### How I did it

setup.py version change

### How to verify it

install with latest ape

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
