### PR TITLE
fix: allow working without connection

### DIFF
--- a/ape_ledger/accounts.py
+++ b/ape_ledger/accounts.py
@@ -67,7 +67,8 @@ class LedgerAccount(AccountAPI):
 
     @property
     def address(self) -> AddressType:
-        return self.provider.network.ecosystem.decode_address(self.account_file["address"])
+        ecosystem = self.network_manager.get_ecosystem("ethereum")
+        return ecosystem.decode_address(self.account_file["address"])
 
     @property
     def hdpath(self) -> HDAccountPath:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,7 @@
 import pytest
 from ape import accounts
 from ape._cli import cli
-from ape.managers.accounts import AccountManager
 
-from ape_ledger import LedgerAccount
 from ape_ledger.hdpath import HDBasePath
 
 from .conftest import TEST_ADDRESS, TEST_HD_PATH, assert_account
@@ -15,16 +13,6 @@ def _get_container():
 
 TEST_ALIAS = "__integration_test_alias__"
 TEST_ACCOUNT_PATH = _get_container().data_folder.joinpath(f"{TEST_ALIAS}.json")
-
-
-@pytest.fixture
-def mock_account_manager(mocker):
-    return mocker.MagicMock(spec=AccountManager)
-
-
-@pytest.fixture
-def mock_account(mocker):
-    return mocker.MagicMock(spec=LedgerAccount)
 
 
 @pytest.fixture
@@ -83,9 +71,7 @@ def test_add(runner, mock_device_connection):
     assert_account(expected_path, expected_hdpath=expected_hd_path)
 
 
-def test_add_when_hd_path_specified(
-    runner, mock_ethereum_app, mock_device_connection, mock_account
-):
+def test_add_when_hd_path_specified(runner, mock_ethereum_app, mock_device_connection):
     test_hd_path = "m/44'/60'/0'"
     mock_ethereum_app.hd_root_path = HDBasePath(test_hd_path)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -49,8 +49,9 @@ def _get_account_path(alias=TEST_ALIAS):
     return container.data_folder.joinpath(f"{alias}.json")
 
 
-def test_list(runner, existing_account):
-    result = runner.invoke(cli, ["ledger", "list"])
+@pytest.mark.parametrize("cmd", (["ledger", "list"], ["accounts", "list", "--all"]))
+def test_list(runner, existing_account, cmd):
+    result = runner.invoke(cli, cmd)
     assert result.exit_code == 0, result.output
     assert TEST_ALIAS in result.output
     assert TEST_ADDRESS.lower() in result.output.lower()


### PR DESCRIPTION
### What I did

Bug where you needed to be connected to a provider to see accounts, causing `ape ledger list` to not work.
This was a regression from the change in ape but somehow did not fail the tests?? I am not sure how.

### How I did it

* Grab the `ethereum` ecosystem manually.
* Also created this issue as a future: https://github.com/ApeWorX/ape-ledger/issues/23

### How to verify it

Tests pass again.
Can use `ape ledger list`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
