### PR TITLE
feat: CLI display before signing transactions and messages

### DIFF
--- a/ape_ledger/accounts.py
+++ b/ape_ledger/accounts.py
@@ -1,7 +1,8 @@
 import json
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Union
 
+import click
 import rlp  # type: ignore
 from ape.api import AccountAPI, AccountContainerAPI, TransactionAPI
 from ape.logging import logger
@@ -86,8 +87,10 @@ class LedgerAccount(AccountAPI):
         return self.account_client
 
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
-        version = msg.version
+        if not self._prompt_to_sign(msg):
+            return None
 
+        version = msg.version
         if version == b"E":
             signed_msg = self._client.sign_personal_message(msg.body)
         elif version == b"\x01":
@@ -119,6 +122,9 @@ class LedgerAccount(AccountAPI):
         return MessageSignature(v, r, s)  # type: ignore
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
+        if not self._prompt_to_sign(txn):
+            return None
+
         txn_type = TransactionType(txn.type)  # In case it is not enum
         if txn_type == TransactionType.STATIC:
             serializable_txn = StaticFeeTransaction(**txn.dict())
@@ -137,3 +143,10 @@ class LedgerAccount(AccountAPI):
             v = (chain_id * 2 + 35) + ecc_parity
 
         return TransactionSignature(v, r, s)  # type: ignore
+
+    def _prompt_to_sign(self, data: Union[SignableMessage, TransactionAPI]) -> bool:
+        if not click.confirm(f"{data}\n\nSign: "):
+            return False
+
+        click.echo("Please follow the prompts on your device.")
+        return True

--- a/ape_ledger/accounts.py
+++ b/ape_ledger/accounts.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Iterator, Optional, Union
+from typing import Iterator, Optional
 
 import click
 import rlp  # type: ignore
@@ -87,9 +87,7 @@ class LedgerAccount(AccountAPI):
         return self.account_client
 
     def sign_message(self, msg: SignableMessage) -> Optional[MessageSignature]:
-        if not self._prompt_to_sign(msg):
-            return None
-
+        click.echo(f"{msg}\nPlease follow the prompts on your device.")
         version = msg.version
         if version == b"E":
             signed_msg = self._client.sign_personal_message(msg.body)
@@ -122,9 +120,7 @@ class LedgerAccount(AccountAPI):
         return MessageSignature(v, r, s)  # type: ignore
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
-        if not self._prompt_to_sign(txn):
-            return None
-
+        click.echo(f"{txn}\nPlease follow the prompts on your device.")
         txn_type = TransactionType(txn.type)  # In case it is not enum
         if txn_type == TransactionType.STATIC:
             serializable_txn = StaticFeeTransaction(**txn.dict())
@@ -143,10 +139,3 @@ class LedgerAccount(AccountAPI):
             v = (chain_id * 2 + 35) + ecc_parity
 
         return TransactionSignature(v, r, s)  # type: ignore
-
-    def _prompt_to_sign(self, data: Union[SignableMessage, TransactionAPI]) -> bool:
-        if not click.confirm(f"{data}\n\nSign: "):
-            return False
-
-        click.echo("Please follow the prompts on your device.")
-        return True

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -12,8 +12,7 @@ from eth_account.messages import SignableMessage
 
 from ape_ledger.accounts import AccountContainer, LedgerAccount
 from ape_ledger.exceptions import LedgerSigningError
-
-from .conftest import TEST_ADDRESS, TEST_ALIAS, TEST_HD_PATH, assert_account
+from tests.conftest import TEST_ADDRESS, TEST_ALIAS, TEST_HD_PATH, assert_account
 
 
 class Person(EIP712Type):
@@ -104,10 +103,33 @@ def account(mock_container):
 
 
 @pytest.fixture
-def sign_txn_spy(mocker):
-    spy = mocker.spy(LedgerAccount, "_client")
-    spy.sign_transaction.return_value = (0, b"r", b"s")
-    return spy
+def client_spy(mocker):
+    return mocker.spy(LedgerAccount, "_client")
+
+
+@pytest.fixture
+def sign_personal_msg_spy(client_spy):
+    client_spy.sign_personal_message.return_value = (1, b"r", b"s")
+    return client_spy
+
+
+@pytest.fixture
+def sign_typed_msg_spy(client_spy):
+    client_spy.sign_typed_data.return_value = (2, b"r", b"s")
+    return client_spy
+
+
+@pytest.fixture
+def sign_txn_spy(client_spy):
+    client_spy.sign_transaction.return_value = (0, b"r", b"s")
+    return client_spy
+
+
+@pytest.fixture
+def signable_message():
+    return SignableMessage(
+        version=b"E", header=b"thereum Signed Message:\n6", body=b"I\xe2\x99\xa5SF"
+    )
 
 
 class TestAccountContainer:
@@ -124,33 +146,33 @@ class TestLedgerAccount:
     def test_hdpath_returns_address_from_file(self, account):
         assert account.hdpath.path == TEST_HD_PATH
 
-    def test_sign_message_personal(self, mocker, account, account_connection):
-        spy = mocker.spy(LedgerAccount, "_client")
-        spy.sign_personal_message.return_value = (0, b"r", b"s")
+    def test_sign_message_personal(
+        self, runner, account, account_connection, sign_personal_msg_spy, signable_message
+    ):
+        with runner.isolation(input="y\n"):
+            actual_v, actual_r, actual_s = account.sign_message(signable_message)
 
-        message = SignableMessage(
-            version=b"E", header=b"thereum Signed Message:\n6", body=b"I\xe2\x99\xa5SF"
-        )
-        actual_v, actual_r, actual_s = account.sign_message(message)
+            assert actual_v == 0
+            assert actual_r == b"r"
+            assert actual_s == b"s"
+            sign_personal_msg_spy.sign_personal_message.assert_called_once_with(
+                signable_message.body
+            )
 
-        assert actual_v == 1
-        assert actual_r == b"r"
-        assert actual_s == b"s"
-        spy.sign_personal_message.assert_called_once_with(message.body)
-
-    def test_sign_message_typed(self, mocker, account, account_connection):
-        spy = mocker.spy(LedgerAccount, "_client")
-        spy.sign_typed_data.return_value = (0, b"r", b"s")
-
+    def test_sign_message_typed(self, runner, account, account_connection, sign_typed_msg_spy):
         message = TEST_TYPED_MESSAGE.signable_message
-        actual_v, actual_r, actual_s = account.sign_message(message)
 
-        assert actual_v == 1
-        assert actual_r == b"r"
-        assert actual_s == b"s"
-        spy.sign_typed_data.assert_called_once_with(message.header, message.body)
+        with runner.isolation(input="y\n"):
+            actual = account.sign_message(message)
+            assert actual
+            actual_v, actual_r, actual_s = actual
 
-    def test_sign_message_unsupported(self, account, account_connection):
+            assert actual_v == 1
+            assert actual_r == b"r"
+            assert actual_s == b"s"
+            sign_typed_msg_spy.sign_typed_data.assert_called_once_with(message.header, message.body)
+
+    def test_sign_message_unsupported(self, runner, account, account_connection):
         unsupported_version = b"X"
         message = SignableMessage(
             version=unsupported_version,
@@ -158,11 +180,16 @@ class TestLedgerAccount:
             body=b"I\xe2\x99\xa5SF",
         )
         with pytest.raises(LedgerSigningError) as err:
-            account.sign_message(message)
+            with runner.isolation(input="y\n"):
+                account.sign_message(message)
 
         actual = str(err.value)
         expected = f"Unsupported message-signing specification, (version={unsupported_version})."
         assert actual == expected
+
+    def test_sign_message_when_says_no(self, runner, account, account_connection, signable_message):
+        with runner.isolation(input="n\n"):
+            assert not account.sign_message(signable_message)
 
     @pytest.mark.parametrize(
         "txn,expected",
@@ -185,7 +212,15 @@ class TestLedgerAccount:
             ),
         ),
     )
-    def test_sign_transaction(self, txn, expected, sign_txn_spy, account, account_connection):
-        account.sign_transaction(txn)
+    def test_sign_transaction(
+        self, runner, txn, expected, sign_txn_spy, account, account_connection
+    ):
+        with runner.isolation(input="y\n"):
+            account.sign_transaction(txn)
+
         actual = sign_txn_spy.sign_transaction.call_args[0][0].hex()
         assert actual == expected
+
+    def test_sign_transaction_when_says_no(self, runner, sign_txn_spy, account, account_connection):
+        with runner.isolation(input="n\n"):
+            assert not account.sign_transaction(TEST_STATIC_FEE_TXN)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -147,32 +147,28 @@ class TestLedgerAccount:
         assert account.hdpath.path == TEST_HD_PATH
 
     def test_sign_message_personal(
-        self, runner, account, account_connection, sign_personal_msg_spy, signable_message
+        self, account, account_connection, sign_personal_msg_spy, signable_message
     ):
-        with runner.isolation(input="y\n"):
-            actual_v, actual_r, actual_s = account.sign_message(signable_message)
+        actual_v, actual_r, actual_s = account.sign_message(signable_message)
 
-            assert actual_v == 0
-            assert actual_r == b"r"
-            assert actual_s == b"s"
-            sign_personal_msg_spy.sign_personal_message.assert_called_once_with(
-                signable_message.body
-            )
+        assert actual_v == 0
+        assert actual_r == b"r"
+        assert actual_s == b"s"
+        sign_personal_msg_spy.sign_personal_message.assert_called_once_with(signable_message.body)
 
-    def test_sign_message_typed(self, runner, account, account_connection, sign_typed_msg_spy):
+    def test_sign_message_typed(self, account, account_connection, sign_typed_msg_spy):
         message = TEST_TYPED_MESSAGE.signable_message
 
-        with runner.isolation(input="y\n"):
-            actual = account.sign_message(message)
-            assert actual
-            actual_v, actual_r, actual_s = actual
+        actual = account.sign_message(message)
+        assert actual
+        actual_v, actual_r, actual_s = actual
 
-            assert actual_v == 1
-            assert actual_r == b"r"
-            assert actual_s == b"s"
-            sign_typed_msg_spy.sign_typed_data.assert_called_once_with(message.header, message.body)
+        assert actual_v == 1
+        assert actual_r == b"r"
+        assert actual_s == b"s"
+        sign_typed_msg_spy.sign_typed_data.assert_called_once_with(message.header, message.body)
 
-    def test_sign_message_unsupported(self, runner, account, account_connection):
+    def test_sign_message_unsupported(self, account, account_connection):
         unsupported_version = b"X"
         message = SignableMessage(
             version=unsupported_version,
@@ -180,16 +176,11 @@ class TestLedgerAccount:
             body=b"I\xe2\x99\xa5SF",
         )
         with pytest.raises(LedgerSigningError) as err:
-            with runner.isolation(input="y\n"):
-                account.sign_message(message)
+            account.sign_message(message)
 
         actual = str(err.value)
         expected = f"Unsupported message-signing specification, (version={unsupported_version})."
         assert actual == expected
-
-    def test_sign_message_when_says_no(self, runner, account, account_connection, signable_message):
-        with runner.isolation(input="n\n"):
-            assert not account.sign_message(signable_message)
 
     @pytest.mark.parametrize(
         "txn,expected",
@@ -212,15 +203,7 @@ class TestLedgerAccount:
             ),
         ),
     )
-    def test_sign_transaction(
-        self, runner, txn, expected, sign_txn_spy, account, account_connection
-    ):
-        with runner.isolation(input="y\n"):
-            account.sign_transaction(txn)
-
+    def test_sign_transaction(self, txn, expected, sign_txn_spy, account, account_connection):
+        account.sign_transaction(txn)
         actual = sign_txn_spy.sign_transaction.call_args[0][0].hex()
         assert actual == expected
-
-    def test_sign_transaction_when_says_no(self, runner, sign_txn_spy, account, account_connection):
-        with runner.isolation(input="n\n"):
-            assert not account.sign_transaction(TEST_STATIC_FEE_TXN)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -172,8 +172,9 @@ class TestLedgerAccount:
         expected = f"Unsupported message-signing specification, (version={unsupported_version})."
         assert actual == expected
 
-        # Should NOT print out faulty message
-        assert not capsys.readouterr().out
+        output = capsys.readouterr()
+        assert str(message) not in output.out
+        assert "Please follow the prompts on your device." not in output.out
 
     @pytest.mark.parametrize(
         "txn,expected",

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -124,7 +124,7 @@ class TestLedgerAccount:
     def test_hdpath_returns_address_from_file(self, account):
         assert account.hdpath.path == TEST_HD_PATH
 
-    def test_sign_message_personal(self, mocker, account, account_connection):
+    def test_sign_message_personal(self, mocker, account, account_connection, capsys):
         spy = mocker.spy(LedgerAccount, "_client")
         spy.sign_personal_message.return_value = (0, b"r", b"s")
 
@@ -138,7 +138,11 @@ class TestLedgerAccount:
         assert actual_s == b"s"
         spy.sign_personal_message.assert_called_once_with(message.body)
 
-    def test_sign_message_typed(self, mocker, account, account_connection):
+        output = capsys.readouterr()
+        assert str(message) in output.out
+        assert "Please follow the prompts on your device." in output.out
+
+    def test_sign_message_typed(self, mocker, account, account_connection, capsys):
         spy = mocker.spy(LedgerAccount, "_client")
         spy.sign_typed_data.return_value = (0, b"r", b"s")
 
@@ -150,7 +154,11 @@ class TestLedgerAccount:
         assert actual_s == b"s"
         spy.sign_typed_data.assert_called_once_with(message.header, message.body)
 
-    def test_sign_message_unsupported(self, account, account_connection):
+        output = capsys.readouterr()
+        assert str(message) in output.out
+        assert "Please follow the prompts on your device." in output.out
+
+    def test_sign_message_unsupported(self, account, account_connection, capsys):
         unsupported_version = b"X"
         message = SignableMessage(
             version=unsupported_version,
@@ -163,6 +171,9 @@ class TestLedgerAccount:
         actual = str(err.value)
         expected = f"Unsupported message-signing specification, (version={unsupported_version})."
         assert actual == expected
+
+        # Should NOT print out faulty message
+        assert not capsys.readouterr().out
 
     @pytest.mark.parametrize(
         "txn,expected",
@@ -185,7 +196,13 @@ class TestLedgerAccount:
             ),
         ),
     )
-    def test_sign_transaction(self, txn, expected, sign_txn_spy, account, account_connection):
+    def test_sign_transaction(
+        self, txn, expected, sign_txn_spy, account, account_connection, capsys
+    ):
         account.sign_transaction(txn)
         actual = sign_txn_spy.sign_transaction.call_args[0][0].hex()
         assert actual == expected
+
+        output = capsys.readouterr()
+        assert str(txn) in output.out
+        assert "Please follow the prompts on your device." in output.out


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #19 

### How I did it

Copy `ape_accounts` core plugin

### How to verify it

Sign messages and transactions using your ledger account.
Ensure you are prompted on the CLI first and that you are shown the message or transaction you are signing.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
