### PR TITLE
fix: issue with 'v' byte when signing messages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -16,7 +16,7 @@ $ ape plugins list
 ```
 
 * Python Version: x.x.x
-* OS: osx/linux/win
+* OS: macOS/linux/win
 
 ### What went wrong?
 

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -21,7 +21,7 @@ jobs:
         - name: Install Dependencies
           run: |
             python -m pip install --upgrade pip
-            pip install .[lint]
+            pip install "commitizen>=2.19,<2.20"
 
         - name: Check commit history
           run: cz check --rev-range $(git rev-list --all --reverse | head -1)..HEAD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
     rev: v0.971
     hooks:
     -   id: mypy
-        additional_dependencies: [types-PyYAML, types-requests]
 
 
 default_language_version:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ cd ape-ledger
 python3 -m venv venv
 source venv/bin/activate
 
-# Install ape into the virtual environment
+# Install ape-ledger into the virtual environment
 python setup.py install
 
 # Install the developer dependencies (-e is interactive mode)

--- a/ape_ledger/_cli.py
+++ b/ape_ledger/_cli.py
@@ -134,6 +134,9 @@ def sign_message(cli_ctx, alias, message, network):
 
 def _sign_message(account: AccountAPI, message: SignableMessage):
     signature = account.sign_message(message)
+    if not signature:
+        raise Abort("Failed to sign message.")
+
     signature_bytes = signature.encode_rsv()
 
     # Verify signature

--- a/ape_ledger/_cli.py
+++ b/ape_ledger/_cli.py
@@ -120,6 +120,7 @@ def sign_message(cli_ctx, alias, message):
     eip191message = encode_defunct(text=message)
     account = accounts.load(alias)
     signature = account.sign_message(eip191message)
+
     if not signature:
         cli_ctx.abort("Failed to sign message.")
 

--- a/ape_ledger/_cli.py
+++ b/ape_ledger/_cli.py
@@ -3,7 +3,6 @@ from typing import List
 import click
 from ape import accounts
 from ape.cli import (
-    Abort,
     ape_cli_context,
     existing_alias_argument,
     non_existing_alias_argument,
@@ -122,14 +121,14 @@ def sign_message(cli_ctx, alias, message):
     account = accounts.load(alias)
     signature = account.sign_message(eip191message)
     if not signature:
-        raise Abort("Failed to sign message.")
+        cli_ctx.abort("Failed to sign message.")
 
     signature_bytes = signature.encode_rsv()
 
     # Verify signature
     signer = Account.recover_message(eip191message, signature=signature_bytes)
     if signer != account.address:
-        raise Abort(f"Signer resolves incorrectly, got {signer}, expected {account.address}.")
+        cli_ctx.abort(f"Signer resolves incorrectly, got {signer}, expected {account.address}.")
 
     # Message signed successfully, return signature
     click.echo(signature_bytes.hex())

--- a/ape_ledger/accounts.py
+++ b/ape_ledger/accounts.py
@@ -114,10 +114,6 @@ class LedgerAccount(AccountAPI):
                 f"Using default value '{chain_id}' for determining parity bit."
             )
 
-        # Compute parity
-        size = chain_id * 2 + 35
-        ecc_parity = v - (size % 256) if size + 1 > 255 else (v + 1) % 2
-        v = (chain_id * 2 + 35) + ecc_parity
         return MessageSignature(v, r, s)  # type: ignore
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:

--- a/ape_ledger/accounts.py
+++ b/ape_ledger/accounts.py
@@ -108,20 +108,16 @@ class LedgerAccount(AccountAPI):
         if self.network_manager.active_provider:
             chain_id = self.provider.network.chain_id
         else:
-            chain_id = 0
+            chain_id = 1
             logger.warning(
                 f"The chain ID is not known. "
                 f"Using default value '{chain_id}' for determining parity bit."
             )
 
         # Compute parity
-        if (chain_id * 2 + 35) + 1 > 255:
-            ecc_parity = v - ((chain_id * 2 + 35) % 256)
-        else:
-            ecc_parity = (v + 1) % 2
-
-        v = int("%02X" % ecc_parity, 16)
-
+        size = chain_id * 2 + 35
+        ecc_parity = v - (size % 256) if size + 1 > 255 else (v + 1) % 2
+        v = (chain_id * 2 + 35) + ecc_parity
         return MessageSignature(v, r, s)  # type: ignore
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:

--- a/ape_ledger/accounts.py
+++ b/ape_ledger/accounts.py
@@ -5,7 +5,6 @@ from typing import Iterator, Optional, Union
 import click
 import rlp  # type: ignore
 from ape.api import AccountAPI, AccountContainerAPI, TransactionAPI
-from ape.logging import logger
 from ape.types import AddressType, MessageSignature, TransactionSignature
 from ape_ethereum.transactions import TransactionType
 from eth_account.messages import SignableMessage
@@ -104,16 +103,6 @@ class LedgerAccount(AccountAPI):
             )
 
         v, r, s = signed_msg
-
-        if self.network_manager.active_provider:
-            chain_id = self.provider.network.chain_id
-        else:
-            chain_id = 1
-            logger.warning(
-                f"The chain ID is not known. "
-                f"Using default value '{chain_id}' for determining parity bit."
-            )
-
         return MessageSignature(v, r, s)  # type: ignore
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:

--- a/ape_ledger/client.py
+++ b/ape_ledger/client.py
@@ -402,8 +402,7 @@ def connect_to_ethereum_account(
     Create an account client using an active device connection.
     """
 
-    device = connect_to_device()
-    return LedgerEthereumAccountClient(device, address, hd_account_path)
+    return LedgerEthereumAccountClient(device_manager.device, address, hd_account_path)
 
 
 def connect_to_ethereum_app(hd_path: HDBasePath) -> LedgerEthereumAppClient:
@@ -412,27 +411,37 @@ def connect_to_ethereum_app(hd_path: HDBasePath) -> LedgerEthereumAppClient:
     using an active device connection.
     """
 
-    device = connect_to_device()
-    return LedgerEthereumAppClient(device, hd_path)
+    return LedgerEthereumAppClient(device_manager.device, hd_path)
 
 
-def connect_to_device() -> LedgerUsbDeviceClient:
-    """
-    Create a Ledger device client and connect to it.
-    """
+class DeviceManager:
+    _device: Optional[LedgerUsbDeviceClient] = None
 
-    hid_path = _get_hid_device_path()
-    if hid_path is None:
-        raise LedgerUsbError("No Ledger USB device found.")
+    @property
+    def device(self) -> LedgerUsbDeviceClient:
+        """
+        Create a Ledger device client and connect to it.
+        """
 
-    device = _get_device(hid_path)
-    return LedgerUsbDeviceClient(device)
+        if self._device:
+            return self._device
+
+        hid_path = _get_hid_device_path()
+        if hid_path is None:
+            raise LedgerUsbError("No Ledger USB device found.")
+
+        device = _get_device(hid_path)
+        self._device = LedgerUsbDeviceClient(device)
+        return self._device
+
+
+device_manager = DeviceManager()
 
 
 __all__ = [
-    "connect_to_device",
     "connect_to_ethereum_account",
     "connect_to_ethereum_app",
+    "device_manager",
     "LedgerEthereumAccountClient",
     "LedgerEthereumAppClient",
     "LedgerUsbDeviceClient",

--- a/ape_ledger/client.py
+++ b/ape_ledger/client.py
@@ -416,6 +416,7 @@ def connect_to_ethereum_app(hd_path: HDBasePath) -> LedgerEthereumAppClient:
 
 class DeviceManager:
     _device: Optional[LedgerUsbDeviceClient] = None
+    _client_cls = LedgerUsbDeviceClient
 
     @property
     def device(self) -> LedgerUsbDeviceClient:
@@ -431,7 +432,7 @@ class DeviceManager:
             raise LedgerUsbError("No Ledger USB device found.")
 
         device = _get_device(hid_path)
-        self._device = LedgerUsbDeviceClient(device)
+        self._device = self._client_cls(device)
         return self._device
 
 

--- a/setup.py
+++ b/setup.py
@@ -90,5 +90,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -55,15 +55,16 @@ setup(
     url="https://github.com/ApeWorX/ape-ledger",
     include_package_data=True,
     install_requires=[
-        "click>=8.0.0",
+        "click",  # Use same version as eth-ape
+        "eth-ape>=0.4.5,<0.5.0",
         "hidapi==0.10.1",
-        "eth-ape>=0.4.0,<0.5.0",
-        "eth-account>=0.5.6,<0.6.0",
-        "eth-typing>=2.2.2",
-        "eth-utils>=1.10.0",
-        "hexbytes==0.2.2",
         "importlib-metadata",
         "rlp>=2.0.1",
+        # EF Dependencies
+        "eth-account",  # Use same version as eth-ape
+        "eth-typing",  # Influenced by eth-ape
+        "eth-utils",  # Use same version as eth-ape
+        "hexbytes",  # Use same version as eth-ape
     ],
     entry_points={
         "ape_cli_subcommands": [

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -130,7 +130,7 @@ class TestLedgerAccount:
         )
         actual_v, actual_r, actual_s = account.sign_message(message)
 
-        assert actual_v == 262554645881088
+        assert actual_v == 0
         assert actual_r == b"r"
         assert actual_s == b"s"
         spy.sign_personal_message.assert_called_once_with(message.body)
@@ -146,7 +146,7 @@ class TestLedgerAccount:
         message = TEST_TYPED_MESSAGE.signable_message
         actual_v, actual_r, actual_s = account.sign_message(message)
 
-        assert actual_v == 262554645881088
+        assert actual_v == 0
         assert actual_r == b"r"
         assert actual_s == b"s"
         spy.sign_typed_data.assert_called_once_with(message.header, message.body)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -123,14 +123,14 @@ class TestLedgerAccount:
 
     def test_sign_message_personal(self, mocker, account, account_connection, capsys):
         spy = mocker.spy(LedgerAccount, "_client")
-        spy.sign_personal_message.return_value = (0, b"r", b"s")
+        spy.sign_personal_message.return_value = (27, b"r", b"s")
 
         message = SignableMessage(
             version=b"E", header=b"thereum Signed Message:\n6", body=b"I\xe2\x99\xa5SF"
         )
         actual_v, actual_r, actual_s = account.sign_message(message)
 
-        assert actual_v == 0
+        assert actual_v == 27
         assert actual_r == b"r"
         assert actual_s == b"s"
         spy.sign_personal_message.assert_called_once_with(message.body)
@@ -141,12 +141,12 @@ class TestLedgerAccount:
 
     def test_sign_message_typed(self, mocker, account, account_connection, capsys):
         spy = mocker.spy(LedgerAccount, "_client")
-        spy.sign_typed_data.return_value = (0, b"r", b"s")
+        spy.sign_typed_data.return_value = (27, b"r", b"s")
 
         message = TEST_TYPED_MESSAGE.signable_message
         actual_v, actual_r, actual_s = account.sign_message(message)
 
-        assert actual_v == 0
+        assert actual_v == 27
         assert actual_r == b"r"
         assert actual_s == b"s"
         spy.sign_typed_data.assert_called_once_with(message.header, message.body)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -130,7 +130,7 @@ class TestLedgerAccount:
         )
         actual_v, actual_r, actual_s = account.sign_message(message)
 
-        assert actual_v == 1
+        assert actual_v == 262554645881088
         assert actual_r == b"r"
         assert actual_s == b"s"
         spy.sign_personal_message.assert_called_once_with(message.body)
@@ -146,7 +146,7 @@ class TestLedgerAccount:
         message = TEST_TYPED_MESSAGE.signable_message
         actual_v, actual_r, actual_s = account.sign_message(message)
 
-        assert actual_v == 1
+        assert actual_v == 262554645881088
         assert actual_r == b"r"
         assert actual_s == b"s"
         spy.sign_typed_data.assert_called_once_with(message.header, message.body)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,6 @@
 import ape_ledger.client as client_module
 
 
-def test_device_connects_once():
-    device_0 = client_module.device_manager.device
-    device_1 = client_module.device_manager.device
-    assert device_0 == device_1
+def test_device_connects_once(mock_device):
+    client_module.device_manager._device = mock_device
+    assert client_module.device_manager.device == mock_device

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,7 @@
+import ape_ledger.client as client_module
+
+
+def test_device_connects_once():
+    device_0 = client_module.device_manager.device
+    device_1 = client_module.device_manager.device
+    assert device_0 == device_1


### PR DESCRIPTION
### What I did

Parity bit calculation is not necessary when signing messages it turns out.
That is only for certain types of transactions.
Thus, it was causing errors.
This PR fixes that as well as fixes the CLI helper methods.

### How I did it

Delete parity bit calculation for signing messages

### How to verify it

Sign messages using various networks

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
